### PR TITLE
StringGetMultiple for use with Symfony Cache

### DIFF
--- a/src/Command/StringGetMultiple.php
+++ b/src/Command/StringGetMultiple.php
@@ -21,7 +21,7 @@ class StringGetMultiple extends BaseStringGetMultiple implements CompressibleCom
         return $this->decompress($data);
     }
 
-    private function decompress(?string $data) 
+    private function decompress(string $data = null)
     {
         if (!$this->compressor->isCompressed($data)) {
             return $data;

--- a/src/Command/StringGetMultiple.php
+++ b/src/Command/StringGetMultiple.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace B1rdex\PredisCompressible\Command;
+
+use Predis\Command\StringGetMultiple as BaseStringGetMultiple;
+
+class StringGetMultiple extends BaseStringGetMultiple implements CompressibleCommandInterface
+{
+    use CompressibleCommandTrait;
+
+    public function parseResponse($data)
+    {
+        if (is_array($data)) {
+            return array_map(function($item) {
+                return $this->decompress($item);
+            }, $data);
+        }
+
+        return $this->decompress($data);
+    }
+
+    private function decompress(?string $data) 
+    {
+        if (!$this->compressor->isCompressed($data)) {
+            return $data;
+        }
+
+        return $this->compressor->decompress($data);
+    }
+}

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -167,6 +167,7 @@ class ClientTest extends TestCase
         self::assertSame([$value1], $sut->mget([$key1]));
         self::assertNotSame([$value1, $value2, $value3], $this->getOriginalClient()->mget([$key1, $key2, $key3]));
 
-        self::assertEmpty($sut->mget(['not', 'existent']));
+        $shouldBeEmpty = $sut->mget(['not', 'existent']);
+        self::assertEmpty($shouldBeEmpty, print_r($shouldBeEmpty, true));
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -167,7 +167,6 @@ class ClientTest extends TestCase
         self::assertSame([$value1], $sut->mget([$key1]));
         self::assertNotSame([$value1, $value2, $value3], $this->getOriginalClient()->mget([$key1, $key2, $key3]));
 
-        $shouldBeEmpty = $sut->mget(['not', 'existent']);
-        self::assertEmpty($shouldBeEmpty, print_r($shouldBeEmpty, true));
+        self::assertSame([null, null], $sut->mget(['not', 'existent']));
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sp\Tests\PredisCompress;
 
 use B1rdex\PredisCompressible\Command\StringGet;
+use B1rdex\PredisCompressible\Command\StringGetMultiple;
 use B1rdex\PredisCompressible\Command\StringSet;
 use B1rdex\PredisCompressible\Command\StringSetExpire;
 use B1rdex\PredisCompressible\Command\StringSetPreserve;
@@ -64,6 +65,7 @@ class ClientTest extends TestCase
                     $profile->defineCommand('SETEX', StringSetExpire::class);
                     $profile->defineCommand('SETNX', StringSetPreserve::class);
                     $profile->defineCommand('GET', StringGet::class);
+                    $profile->defineCommand('MGET', StringGetMultiple::class);
                 }
 
                 return $profile;
@@ -142,5 +144,29 @@ class ClientTest extends TestCase
         $sut->set($key, null);
 
         $this->assertEquals(1, $sut->exists($key));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_allow_mget()
+    {
+        $sut = $this->getCompressedClient();
+
+        $key1 = 'test1';
+        $key2 = 'test2';
+        $key3 = 'test3';
+        $value1 = 'value compressed1';
+        $value2 = 'value compressed2';
+        $value3 = 'value compressed3';
+        $sut->set($key1, $value1);
+        $sut->set($key2, $value2);
+        $sut->set($key3, $value3);
+
+        self::assertSame([$value1, $value2, $value3], $sut->mget([$key1, $key2, $key3]));
+        self::assertSame([$value1], $sut->mget([$key1]));
+        self::assertNotSame([$value1, $value2, $value3], $this->getOriginalClient()->mget([$key1, $key2, $key3]));
+
+        self::assertEmpty($sut->mget(['not', 'existent']));
     }
 }


### PR DESCRIPTION
Since Symfony 3.4.23 (not sure about 2.x, 4.x branches) Symfony went with mget
Usage of the following is no longer valid as it tries to unserialize an invalid value.

```
$profile->defineCommand('SET', StringSet::class);
$profile->defineCommand('SETEX', StringSetExpire::class);
$profile->defineCommand('SETNX', StringSetPreserve::class);
$profile->defineCommand('GET', StringGet::class);
```

Emm, so we need

```$profile->defineCommand('MGET', StringGetMultiple::class);```

Note: `is_array` check is required as mget gets an array, but if only a single key is requested, the call to `self::normalizeArguments` returns a single (`string`? I think also possibly `null`) value